### PR TITLE
totally different way of dealing with associations in API responses

### DIFF
--- a/lib/drowsy/associations/base.rb
+++ b/lib/drowsy/associations/base.rb
@@ -7,14 +7,14 @@ class Drowsy::Associations::Base
     @options = options
   end
 
-  def convert(value)
-    case value
+  def convert(raw_value)
+    case raw_value
     when Hash
-      target_klass.new(value)
+      target_klass.load(raw_value)
     when target_klass
-      value
+      raw_value
     else
-      raise Drowsy::Error, "invalid value (#{value.inspect}) assigned to association: #{parent_klass.name}##{name}"
+      raise Drowsy::Error, "invalid value (#{raw_value.inspect}) assigned to association: #{parent_klass.name}##{name}"
     end
   end
 

--- a/lib/drowsy/associations/behavior.rb
+++ b/lib/drowsy/associations/behavior.rb
@@ -32,6 +32,10 @@ module Drowsy::Associations::Behavior
     def association_names
       associations.keys
     end
+
+    def association_raw_names
+      associations.keys.map { |n| :"raw_#{n}" }
+    end
   end
 
   def associations

--- a/lib/drowsy/associations/belongs_to.rb
+++ b/lib/drowsy/associations/belongs_to.rb
@@ -18,6 +18,7 @@ class Drowsy::Associations::BelongsTo < Drowsy::Associations::Base
         end
 
         define_method "#{name}=".freeze do |model|
+          raise Drowsy::Error, "model must be a #{target_klass}" unless model.is_a?(target_klass)
           instance_variable_set(ivar, model)
           send("#{name}_id=", model.id)
         end

--- a/lib/drowsy/associations/belongs_to.rb
+++ b/lib/drowsy/associations/belongs_to.rb
@@ -13,10 +13,13 @@ class Drowsy::Associations::BelongsTo < Drowsy::Associations::Base
           instance_variable_get(ivar)
         end
 
-        define_method "#{name}=".freeze do |value|
-          converted_value = association.convert(value)
-          instance_variable_set(ivar, converted_value)
-          send("#{name}_id=", converted_value.id)
+        define_method "raw_#{name}=".freeze do |raw_value|
+          send("#{name}=", association.convert(raw_value))
+        end
+
+        define_method "#{name}=".freeze do |model|
+          instance_variable_set(ivar, model)
+          send("#{name}_id=", model.id)
         end
 
         define_method "#{name}_id=".freeze do |value|
@@ -27,7 +30,7 @@ class Drowsy::Associations::BelongsTo < Drowsy::Associations::Base
         end
 
         define_method "build_#{name}" do |attributes = {}|
-          send("#{name}=", m)
+          send("#{name}=", target_klass.new(attributes))
         end
       end
     end

--- a/lib/drowsy/associations/belongs_to.rb
+++ b/lib/drowsy/associations/belongs_to.rb
@@ -18,7 +18,7 @@ class Drowsy::Associations::BelongsTo < Drowsy::Associations::Base
         end
 
         define_method "#{name}=".freeze do |model|
-          raise Drowsy::Error, "model must be a #{target_klass}" unless model.is_a?(target_klass)
+          raise Drowsy::Error, "model must be a #{association.target_klass}" unless model.is_a?(association.target_klass)
           instance_variable_set(ivar, model)
           send("#{name}_id=", model.id)
         end

--- a/lib/drowsy/associations/has_many.rb
+++ b/lib/drowsy/associations/has_many.rb
@@ -14,33 +14,38 @@ class Drowsy::Associations::HasMany < Drowsy::Associations::Base
           instance_variable_get(ivar)
         end
 
-        define_method "#{name}=".freeze do |values|
-          raise Drowsy::Error, 'value must be an Array' unless values.is_a?(Array)
+        define_method "raw_#{name}=".freeze do |raw_values|
+          raise Drowsy::Error, 'value must be an Array' unless raw_values.is_a?(Array)
 
-          converted_values = association.convert_many(values)
-          converted_values.each do |r|
+          send("#{name}=".freeze, association.convert_many(raw_values))
+        end
+
+        define_method "#{name}=".freeze do |models|
+          raise Drowsy::Error, 'models must be an Array' unless models.is_a?(Array)
+
+          models.each do |r|
             r.assign_attributes(association.inverse_of_attr_name => self)
           end
 
-          instance_variable_set(ivar, association.build_proxy(self, converted_values))
+          instance_variable_set(ivar, association.build_proxy(self, models))
         end
       end
     end
   end
 
-  def build_proxy(parent, values = Array.new)
-    AssociationProxy.new(parent, self, values)
+  def build_proxy(parent, models = Array.new)
+    AssociationProxy.new(parent, self, models)
   end
 
-  def convert_many(values)
-    values.map do |v|
-      convert(v)
+  def convert_many(raw_values)
+    raw_values.map do |raw_value|
+      convert(raw_value)
     end
   end
 
   class AssociationProxy < SimpleDelegator
-    def initialize(parent, association, collection)
-      super(collection)
+    def initialize(parent, association, models)
+      super(models)
       @parent = parent
       @association = association
     end

--- a/lib/drowsy/associations/has_many.rb
+++ b/lib/drowsy/associations/has_many.rb
@@ -23,9 +23,9 @@ class Drowsy::Associations::HasMany < Drowsy::Associations::Base
         define_method "#{name}=".freeze do |models|
           raise Drowsy::Error, 'models must be an Array' unless models.is_a?(Array)
 
-          models.each do |r|
-            raise Drowsy::Error, 'models must be an Array' unless models.is_a?(target_klass)
-            r.assign_attributes(association.inverse_of_attr_name => self)
+          models.each do |model|
+            raise Drowsy::Error, "model must be a #{association.target_klass}" unless model.is_a?(association.target_klass)
+            model.assign_attributes(association.inverse_of_attr_name => self)
           end
 
           instance_variable_set(ivar, association.build_proxy(self, models))

--- a/lib/drowsy/associations/has_many.rb
+++ b/lib/drowsy/associations/has_many.rb
@@ -24,6 +24,7 @@ class Drowsy::Associations::HasMany < Drowsy::Associations::Base
           raise Drowsy::Error, 'models must be an Array' unless models.is_a?(Array)
 
           models.each do |r|
+            raise Drowsy::Error, 'models must be an Array' unless models.is_a?(target_klass)
             r.assign_attributes(association.inverse_of_attr_name => self)
           end
 

--- a/lib/drowsy/associations/has_one.rb
+++ b/lib/drowsy/associations/has_one.rb
@@ -16,7 +16,7 @@ class Drowsy::Associations::HasOne < Drowsy::Associations::Base
         end
 
         define_method "#{name}=".freeze do |model|
-          raise Drowsy::Error, "model must be a #{target_klass}" unless model.is_a?(target_klass)
+          raise Drowsy::Error, "model must be a #{association.target_klass}" unless model.is_a?(association.target_klass)
           model.assign_attributes(association.inverse_of_attr_name => self)
           instance_variable_set(ivar, model)
         end

--- a/lib/drowsy/associations/has_one.rb
+++ b/lib/drowsy/associations/has_one.rb
@@ -16,8 +16,8 @@ class Drowsy::Associations::HasOne < Drowsy::Associations::Base
         end
 
         define_method "#{name}=".freeze do |model|
+          raise Drowsy::Error, "model must be a #{target_klass}" unless model.is_a?(target_klass)
           model.assign_attributes(association.inverse_of_attr_name => self)
-
           instance_variable_set(ivar, model)
         end
 

--- a/lib/drowsy/associations/has_one.rb
+++ b/lib/drowsy/associations/has_one.rb
@@ -11,15 +11,18 @@ class Drowsy::Associations::HasOne < Drowsy::Associations::Base
           instance_variable_get(ivar)
         end
 
-        define_method "#{name}=".freeze do |value|
-          converted_value = association.convert(value)
-          converted_value.assign_attributes(association.inverse_of_attr_name => self)
+        define_method "raw_#{name}=".freeze do |raw_value|
+          send("#{name}=", association.convert(raw_value))
+        end
 
-          instance_variable_set(ivar, converted_value)
+        define_method "#{name}=".freeze do |model|
+          model.assign_attributes(association.inverse_of_attr_name => self)
+
+          instance_variable_set(ivar, model)
         end
 
         define_method "build_#{name}" do |attributes = {}|
-          send("#{name}=", attributes)
+          send("#{name}=", target_klass.new(attributes))
         end
       end
     end

--- a/lib/drowsy/fixtures.rb
+++ b/lib/drowsy/fixtures.rb
@@ -43,6 +43,18 @@ class FakeJsonApi < Sinatra::Base
   set :show_exceptions, false
   set :raise_errors, true
 
+  get '/users/:id' do
+    if params['id'] == '404'
+      status 404
+      json nil
+    else
+      json(
+        build_user(id: params['id'])
+      )
+    end
+  end
+
+
   get '/users' do
     json(
       [
@@ -64,9 +76,14 @@ class FakeJsonApi < Sinatra::Base
   end
 
   get '/posts/:id' do
-    json(
-      build_post(id: params['id'])
-    )
+    if params['id'] == '404'
+      status 404
+      json nil
+    else
+      json(
+        build_post(id: params['id'])
+      )
+    end
   end
 
   put '/posts/:id' do

--- a/lib/drowsy/fixtures.rb
+++ b/lib/drowsy/fixtures.rb
@@ -54,7 +54,6 @@ class FakeJsonApi < Sinatra::Base
     end
   end
 
-
   get '/users' do
     json(
       [
@@ -64,6 +63,25 @@ class FakeJsonApi < Sinatra::Base
       ]
     )
   end
+
+  put '/users/:id' do
+    data = MultiJson.load(request.body)
+    if data['name']
+      json(
+        build_user id: params['id'], name: data['name']
+      )
+    else
+      status 422
+      json(
+        errors: {
+          name: [
+            { error: 'blank', message: 'can\'t be blank' },
+          ]
+        }
+      )
+    end
+  end
+
 
   get '/posts' do
     json(
@@ -130,8 +148,8 @@ class FakeJsonApi < Sinatra::Base
     { id: id, title: "Post #{id}", user_id: user_id, junk: "junk" }
   end
 
-  def build_user(id: rand(1..1000))
-    { id: id, name: "User #{id}", posts: [build_post(user_id: id), build_post(user_id: id)] }
+  def build_user(id: rand(1..1000), name: nil)
+    { id: id, name: name || "User #{id}", posts: [build_post(user_id: id), build_post(user_id: id)] }
   end
 
   %w(get post put patch delete).each do |method|

--- a/lib/drowsy/json_parser.rb
+++ b/lib/drowsy/json_parser.rb
@@ -5,7 +5,7 @@ class Drowsy::JsonParser < Faraday::Response::Middleware
   DEFAULT_RESPONSE = '{}'.freeze
 
   def on_complete(env)
-    if json_response?(env) && env.parse_body?
+    if env.parse_body? && json_response?(env)
       env.body = parse_body(env.body)
     end
   end
@@ -28,6 +28,7 @@ class Drowsy::JsonParser < Faraday::Response::Middleware
   end
 
   def json_response?(env)
-    (env.response_headers['content-type'] =~ /\bjson\z/) > -1
+    content_type = env.response_headers['content-type']
+    content_type && (content_type =~ /\bjson\z/) > -1
   end
 end

--- a/lib/drowsy/model.rb
+++ b/lib/drowsy/model.rb
@@ -33,16 +33,23 @@ class Drowsy::Model
     super(new_attributes.extract!(*self.class.assignable_attributes))
   end
 
+  def assign_raw_attributes(raw_attributes)
+    assign_attributes(self.class.translate_raw_attributes(raw_attributes))
+  end
+
   # load an instance from raw attributes
   def self.load(raw_attributes)
-    attrs = raw_attributes.each_with_object({}) do |(key, value), memo|
+    new(**translate_raw_attributes(raw_attributes))
+  end
+
+  def self.translate_raw_attributes(raw_attributes)
+    raw_attributes.each_with_object({}) do |(key, value), memo|
       if association_names.include?(key)
         memo[:"raw_#{key}"] = value
       else
         memo[key] = value
       end
     end
-    new(**attrs)
   end
 
   def persisted?

--- a/lib/drowsy/persistence.rb
+++ b/lib/drowsy/persistence.rb
@@ -9,7 +9,7 @@ class Drowsy::Persistence
   def save
     method = model.persisted? ? :put : :post
     result = perform_http_request(method)
-    model.assign_attributes(result.data)
+    model.assign_raw_attributes(result.data)
     true
   rescue Drowsy::ResourceInvalid => e
     if e.errors

--- a/lib/drowsy/relation.rb
+++ b/lib/drowsy/relation.rb
@@ -22,12 +22,34 @@ class Drowsy::Relation
     build(attributes).tap(&:save!)
   end
 
-  def destroy_existing(id); raise NotImplementedError; end
-  def save_existing(id, attributes); raise NotImplementedError; end
-  def update_existing(id, attributes); raise NotImplementedError; end
+  # given an identifer
+  # send a DELETE request to the resource
+  # with the given id.
+  # @return true/false
+  def destroy_existing(id);
+    klass.load(id: id).destroy
+  end
+
+  # given an identifer and attributes
+  # send a PUT request with the attributes for
+  # the resource with the given id.
+  # @return true/false
+  def update_existing(id, attributes)
+    klass.load(attributes.merge(id: id)).save
+  end
 
   def find(id)
-    where(klass.primary_key => id).fetch.first
+    find_by!(klass.primary_key => id)
+  end
+
+  def find_by(attributes)
+    find_by!(attributes)
+  rescue Drowsy::ResourceNotFound
+    nil
+  end
+
+  def find_by!(attributes)
+    where(attributes).fetch.first
   end
 
   def where(conditions)
@@ -64,7 +86,7 @@ class Drowsy::Relation
   end
 
   def new_instance(attributes)
-    klass.new(attributes.merge(_persisted: true))
+    klass.load(attributes)
   end
 
   def perform_http_request(method)

--- a/lib/drowsy/relation.rb
+++ b/lib/drowsy/relation.rb
@@ -64,7 +64,7 @@ class Drowsy::Relation
   end
 
   def new_instance(attributes)
-    klass.new(attributes)
+    klass.new(attributes.merge(_persisted: true))
   end
 
   def perform_http_request(method)

--- a/lib/drowsy/scoping.rb
+++ b/lib/drowsy/scoping.rb
@@ -4,7 +4,15 @@ module Drowsy::Scoping
   extend ActiveSupport::Concern
 
   class_methods do
-    delegate :find, :where, :create, to: :all
+    delegate(
+      :find, :find_by, :find_by!,
+      :where,
+      :build,
+      :create, :create!,
+      :destroy_existing,
+      :update_existing,
+      to: :all
+    )
 
     def all
       Drowsy::Relation.new(self)


### PR DESCRIPTION
**why?**
I was not pleased with the magic behavior of association setters where they accepted either a raw array/hash OR array of reified objects / reified object.

_So, i decided to do a little refactoring._

The biggest changes are that associations now expose `raw_$assocation_name=` methods on the target class, those methods use `.load` on `Drowsy::Model`s so that `raw_` behavior is applied recursively when loading an API response with embedded association data. 